### PR TITLE
read internal masks

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@ async with COGReader("http://cog.tif") as cog:
 ```
 
 Several filesystems are supported:
-- *HTTP/HTTPS* (`http://`, `https://`)
-- *S3* (`s3://`)
-- *File* (`/`)
+- **HTTP/HTTPS** (`http://`, `https://`)
+- **S3** (`s3://`)
+- **File** (`/`)
 
 ### Metadata
 Generating a [rasterio-style profile](https://rasterio.readthedocs.io/en/latest/topics/profiles.html) for the COG:
@@ -120,7 +120,7 @@ async with COGReader("https://async-cog-reader-test-data.s3.amazonaws.com/naip_i
     assert np.ma.is_masked(tile)
 ```
 
-<p float="middle">
+<p align="center">
   <img src="https://async-cog-reader-test-data.s3.amazonaws.com/readme/masked_tile.jpg" width="300" />
   <img src="https://async-cog-reader-test-data.s3.amazonaws.com/readme/tile_mask.jpg" width="300" /> 
 </p>

--- a/README.md
+++ b/README.md
@@ -122,5 +122,5 @@ async with COGReader("https://async-cog-reader-test-data.s3.amazonaws.com/naip_i
 
 <p align="center">
   <img src="https://async-cog-reader-test-data.s3.amazonaws.com/readme/masked_tile.jpg" width="300" />
-  <img src="https://async-cog-reader-test-data.s3.amazonaws.com/readme/tile_mask.jpg" width="300" /> 
+  <img src="https://async-cog-reader-test-data.s3.amazonaws.com/readme/mask.jpg" width="300" /> 
 </p>

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ async with COGReader("https://async-cog-reader-test-data.s3.amazonaws.com/lzw_co
     first_ifd = cog.ifds[0]
     assert first_ifd.tag_count == 24
 
-    for tag in cog.ifds[0]:
+    for tag in first_ifd:
         print(tag)
 
 >>> Tag(code=258, name='BitsPerSample', tag_type=TagType(format='H', size=2), count=3, length=6, value=(8, 8, 8))

--- a/README.md
+++ b/README.md
@@ -1,35 +1,126 @@
 # [WIP] async-cog-reader [![CircleCI](https://circleci.com/gh/geospatial-jeff/async-cog-reader/tree/master.svg?style=svg)](https://circleci.com/gh/geospatial-jeff/async-cog-reader/tree/master)
 
 
-### Usage
+## Usage
+COGs are opened using the `COGReader` asynchronous context manager:
+
 ```python
-import asyncio
 from async_cog_reader import COGReader
 
-infile = "http://cog.tif"
-
-async def main():
-    async with COGReader(infile) as cog:
-        for ifd in cog.ifds:
-            print(ifd.tags["ImageWidth"].value)
-
-asyncio.run(main())
+async with COGReader("http://cog.tif") as cog:
+    ...
 ```
+
+Several filesystems are supported:
+- *HTTP/HTTPS* (`http://`, `https://`)
+- *S3* (`s3://`)
+- *File* (`/`)
+
+### Metadata
+Generating a [rasterio-style profile](https://rasterio.readthedocs.io/en/latest/topics/profiles.html) for the COG:
+
+```python
+async with COGReader("https://async-cog-reader-test-data.s3.amazonaws.com/lzw_cog.tif") as cog:
+    print(cog.profile)
+
+>>> {'driver': 'GTiff', 'width': 10280, 'height': 12190, 'count': 3, 'dtype': 'uint8', 'transform': Affine(0.6, 0.0, 367188.0,
+       0.0, -0.6, 3777102.0), 'blockxsize': 512, 'blockysize': 512, 'compress': 'lzw', 'interleave': 'pixel', 'crs': 'EPSG:26911', 'tiled': True, 'photometric': 'rgb'}
+```
+
+#### Lower Level Metadata
+A COG is composed of several IFDs, each with many TIFF tags:
+
+```python
+from async_cog_reader.ifd import IFD
+from async_cog_reader.tag import Tag
+
+async with COGReader("https://async-cog-reader-test-data.s3.amazonaws.com/lzw_cog.tif") as cog:
+    for ifd in cog:
+        assert isinstance(ifd, IFD)
+        for tag in ifd:
+            assert isinstance(tag, Tag)
+```
+
+Each IFD contains more granular metadata about the image than what is included in the profile.  For example, finding the
+tilesize for each IFD:
+
+```python
+async with COGReader("https://async-cog-reader-test-data.s3.amazonaws.com/lzw_cog.tif") as cog:
+    for ifd in cog:
+        print(ifd.TileWidth.value, ifd.TileHeight.value)
+
+>>> 512 512
+    128 128
+    128 128
+    128 128
+    128 128
+    128 128
+```
+
+More advanced use cases may need access to tag-level metadata:
+```python
+async with COGReader("https://async-cog-reader-test-data.s3.amazonaws.com/lzw_cog.tif") as cog:
+    first_ifd = cog.ifds[0]
+    assert first_ifd.tag_count == 24
+
+    for tag in cog.ifds[0]:
+        print(tag)
+
+>>> Tag(code=258, name='BitsPerSample', tag_type=TagType(format='H', size=2), count=3, length=6, value=(8, 8, 8))
+    Tag(code=259, name='Compression', tag_type=TagType(format='H', size=2), count=1, length=2, value=5)
+    Tag(code=257, name='ImageHeight', tag_type=TagType(format='H', size=2), count=1, length=2, value=12190)
+    Tag(code=256, name='ImageWidth', tag_type=TagType(format='H', size=2), count=1, length=2, value=10280)
+    ...
+```
+
+### Image Data
+The reader also has methods for reading internal image tiles and performing partial reads.  Currently only jpeg, lzw,
+and webp compressions are supported.
+
+#### Image Tiles
+Reading the top left tile of an image at native resolution:
+
+```python
+async with COGReader("https://async-cog-reader-test-data.s3.amazonaws.com/webp_cog.tif") as cog:
+    x = y = z = 0
+    tile = await cog.get_tile(x, y, z)
+    
+    ifd = cog.ifds[z]
+    assert tile.shape == (ifd.bands, ifd.TileHeight.value, ifd.TileWidth.value)
+```
+
+<p align="center">
+  <img width="300" height="300" src="https://async-cog-reader-test-data.s3.amazonaws.com/readme/naip_top_left_tile.jpg">
+</p>
 
 
 #### Partial Read
+You can read a portion of the image by specifying a bounding box in the native crs of the image and an output shape:
+
 ```python
-import asyncio
-from async_cog_reader import COGReader
-
-infile = "https://async-cog-reader-test-data.s3.amazonaws.com/lzw_cog.tif"
-
-async def main():
-    async with COGReader(infile) as cog:
-        assert cog.epsg == 26911
-        # Projected bounds in native crs of image (in this case `EPSG:26911`)
-        bounds = [367791.55780407554, 3769929.85023777, 368819.5343714542, 3770924.9263116163]
-        tile = await cog.read(bounds=bounds, shape=(256, 256, 3))
-
-asyncio.run(main())
+async with COGReader("https://async-cog-reader-test-data.s3.amazonaws.com/webp_cog.tif") as cog:
+    assert cog.epsg == 26911
+    partial_data = await cog.read(bounds=(368461,3770591,368796,3770921), shape=(512,512))
 ```
+
+<p align="center">
+  <img width="300" height="300" src="https://async-cog-reader-test-data.s3.amazonaws.com/readme/partial_read.jpeg">
+</p>
+
+#### Internal Masks
+If the COG has an internal mask, the returned array will be a masked array:
+
+```python
+import numpy as np
+
+async with COGReader("https://async-cog-reader-test-data.s3.amazonaws.com/naip_image_masked.tif") as cog:
+    assert cog.is_masked
+
+    tile = await cog.get_tile(0,0,0)
+    assert np.ma.is_masked(tile)
+```
+
+<p float="middle">
+  <img src="https://async-cog-reader-test-data.s3.amazonaws.com/readme/masked_tile.jpg" width="300" />
+  <img src="https://async-cog-reader-test-data.s3.amazonaws.com/readme/tile_mask.jpg" width="300" /> 
+</p>

--- a/async_cog_reader/cog.py
+++ b/async_cog_reader/cog.py
@@ -295,7 +295,7 @@ class COGReader:
 
         # Resample to match request size
         resized = resize(
-            clipped, output_shape=shape, preserve_range=True, anti_aliasing=True
+            clipped, output_shape=(ifd.bands, shape[0], shape[1]), preserve_range=True, anti_aliasing=True
         ).astype(ifd.dtype)
 
         return resized

--- a/async_cog_reader/cog.py
+++ b/async_cog_reader/cog.py
@@ -89,6 +89,10 @@ class COGReader:
     def overviews(self):
         return [2 ** (ifd + 1) for ifd in range(len(self.ifds) - 1)]
 
+    @property
+    def is_masked(self):
+        return True if self.mask_ifds else False
+
     async def read_header(self):
         next_ifd_offset = 1
         while next_ifd_offset != 0:
@@ -194,11 +198,10 @@ class COGReader:
         brx, bry = invgt * (bounds[2], bounds[1])
 
         # Calculate tiles
-        eps = 10.0 ** -6 * (2.0 - 1.0 * math.ceil(0.1)) # Resolve floating point errors
-        xmin = math.floor((tlx + eps) / tile_width)
-        xmax = math.floor((brx + eps) / tile_width)
-        ymax = math.floor((bry + eps) / tile_height)
-        ymin = math.floor((tly + eps) / tile_height)
+        xmin = math.floor((tlx + 1e-6) / tile_width)
+        xmax = math.floor((brx + 1e-6) / tile_width)
+        ymax = math.floor((bry + 1e-6) / tile_height)
+        ymin = math.floor((tly + 1e-6) / tile_height)
 
         tile_bounds = (
             xmin * tile_width,

--- a/async_cog_reader/filesystems.py
+++ b/async_cog_reader/filesystems.py
@@ -85,7 +85,7 @@ class LocalFilesystem(Filesystem):
         await self.file.seek(start)
         self._total_bytes_requested += (offset - start)
         self._total_requests += 1
-        return await self.file.read(offset)
+        return await self.file.read(offset+1)
 
     async def close(self):
         await self.file.close()

--- a/async_cog_reader/ifd.py
+++ b/async_cog_reader/ifd.py
@@ -67,24 +67,16 @@ class IFD(OptionalTags, Compression, RequiredTags, BaseIFD):
 
     @property
     def is_full_resolution(self):
-        # https://www.awaresystems.be/imaging/tiff/tifftags/newsubfiletype.html
-        # The image i'm using as a test case to add mask bands doesn't have a `NewSubfileType` on the first IFD although
-        # the spec reads like it should be on every IFD.  So we might not need this first if statement.
         if not self.NewSubfileType:
             return True
-        elif not self.NewSubfileType.value[0]:
-            return True
-        return False
-
-    @property
-    def is_reduced_resolution(self):
-        # https://www.awaresystems.be/imaging/tiff/tifftags/newsubfiletype.html
-        return False if not self.is_full_resolution else True
+        elif self.NewSubfileType.value[0] == 0:
+            return False
+        return True
 
     @property
     def is_mask(self):
-        # https://www.awaresystems.be/imaging/tiff/tifftags/newsubfiletype.html
-        # https://gdal.org/drivers/raster/gtiff.html#internal-nodata-masks
+        # # https://www.awaresystems.be/imaging/tiff/tifftags/newsubfiletype.html
+        # # https://gdal.org/drivers/raster/gtiff.html#internal-nodata-masks
         if self.NewSubfileType:
             if self.NewSubfileType.value[2] == 1 and self.PhotometricInterpretation.value == 4 and self.compression == "deflate":
                 return True

--- a/async_cog_reader/tag.py
+++ b/async_cog_reader/tag.py
@@ -70,14 +70,11 @@ class Tag:
             # something more declarative where each tag defines how to read its data.
             value = struct.unpack(f"{reader._endian}{count}{field_type.format}", data)
             reader.incr(4 - length)
+
             if name == "NewSubfileType":
-                # Decompose the tag value into bit flags
-                bits = [int(b) for b in list(bin(value[0]).lstrip('0b'))]
-                bits.extend([0] * (length - len(bits)))
-                value = bits
-                # tiff spec says this tag has 1 value of length 4, but this makes our life easier downstream
-                count = 4
-                length = 1
+                bit32 = '{:032b}'.format(value[0])
+                value = [[int(x) for x in str(int(bit32)).zfill(3)]]
+
         else:
             value_offset = await reader.read(4, cast_to_int=True)
             end_of_tag = reader.tell()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,6 +13,9 @@ TEST_DATA = [
     "https://async-cog-reader-test-data.s3.amazonaws.com/lzw_cog.tif",  # 3 band lzw (RGBA)
     "https://async-cog-reader-test-data.s3.amazonaws.com/webp_cog.tif",
     "s3://async-cog-reader-test-data/lzw_cog.tif",
+    "https://async-cog-reader-test-data.s3.amazonaws.com/naip_image.tif",
+    "https://async-cog-reader-test-data.s3.amazonaws.com/naip_image_masked.tif",
+    "https://async-cog-reader-test-data.s3.amazonaws.com/int16_deflate.tif",
     os.path.join(DATA_DIR, "cog.tif"),
 ]
 

--- a/tests/test_cog_reader.py
+++ b/tests/test_cog_reader.py
@@ -146,7 +146,7 @@ async def test_cog_read(infile, create_cog_reader):
 
         tile_native_bounds = transform_bounds("EPSG:4326", cog.epsg, *mercantile.bounds(tile))
 
-        arr = await cog.read(tile_native_bounds, (3, 256, 256))
+        arr = await cog.read(tile_native_bounds, (256, 256))
         rio_tile_arr, rio_tile_mask = cogeo.tile(infile, tile.x, tile.y, tile.z, tilesize=256, resampling_method="bilinear")
 
         if np.ma.is_masked(arr):

--- a/tests/test_cog_reader.py
+++ b/tests/test_cog_reader.py
@@ -90,6 +90,7 @@ async def test_cog_read_internal_tile(infile, create_cog_reader):
                 window=window
             )
             if np.ma.is_masked(tile):
+                assert cog.is_masked
                 tile_arr = np.ma.getdata(tile)
                 tile_mask = np.ma.getmask(tile)
                 rio_mask = src.read_masks(1, window=window)

--- a/tests/test_cog_reader.py
+++ b/tests/test_cog_reader.py
@@ -79,20 +79,38 @@ async def test_cog_read_internal_tile(infile, create_cog_reader):
 
         # Make sure tile is the right size
         assert tile.shape == (
+            ifd.SamplesPerPixel.value,
             ifd.TileHeight.value,
             ifd.TileWidth.value,
-            ifd.SamplesPerPixel.value,
         )
 
-        # Rearrange numpy array to match rasterio
-        tile = np.rollaxis(tile, 2, 0)
-
         with rasterio.open(infile) as src:
+            window = Window(0, 0, ifd.TileWidth.value, ifd.TileHeight.value)
             rio_tile = src.read(
-                window=Window(0, 0, ifd.TileWidth.value, ifd.TileHeight.value)
+                window=window
             )
-            assert rio_tile.shape == tile.shape
-            assert np.allclose(tile, rio_tile, rtol=1)
+            if np.ma.is_masked(tile):
+                tile_arr = np.ma.getdata(tile)
+                tile_mask = np.ma.getmask(tile)
+                rio_mask = src.read_masks(1, window=window)
+
+                # Make sure image data is the same
+                assert pytest.approx(np.min(rio_tile), 2) == np.min(tile_arr)
+                assert pytest.approx(np.mean(rio_tile), 2) == np.mean(tile_arr)
+                assert pytest.approx(np.max(rio_tile), 2) == np.max(tile_arr)
+
+                # Make sure mask data is the same
+                rio_mask_counts = np.unique(rio_mask, return_counts=True)
+                tile_mask_counts = np.unique(tile_mask, return_counts=True)
+                assert rio_mask_counts[0].all() == tile_mask_counts[0].all()
+                assert rio_mask_counts[1].all() == tile_mask_counts[1].all()
+            else:
+                # Make sure image data is the same
+                assert pytest.approx(np.min(rio_tile), 2) == np.min(tile)
+                assert pytest.approx(np.mean(rio_tile), 2) == np.mean(tile)
+                assert pytest.approx(np.max(rio_tile), 2) == np.max(tile)
+
+
 
 
 @pytest.mark.asyncio
@@ -118,7 +136,7 @@ async def test_cog_calculate_image_tiles(infile, create_cog_reader):
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("infile", TEST_DATA[:-1])
+@pytest.mark.parametrize("infile", TEST_DATA[:-2])
 async def test_cog_read(infile, create_cog_reader):
     async with create_cog_reader(infile) as cog:
         zoom = math.floor(math.log2((2 * math.pi * 6378137 / 256) / cog.geotransform().a))
@@ -127,10 +145,27 @@ async def test_cog_read(infile, create_cog_reader):
 
         tile_native_bounds = transform_bounds("EPSG:4326", cog.epsg, *mercantile.bounds(tile))
 
-        arr = await cog.read(tile_native_bounds, (256, 256, 3))
-        tile_arr, mask = cogeo.tile(infile, tile.x, tile.y, tile.z, tilesize=256, resampling_method="bilinear")
+        arr = await cog.read(tile_native_bounds, (3, 256, 256))
+        rio_tile_arr, rio_tile_mask = cogeo.tile(infile, tile.x, tile.y, tile.z, tilesize=256, resampling_method="bilinear")
 
-        assert np.allclose(np.rollaxis(arr, 2, 0), tile_arr, rtol=10)
+        if np.ma.is_masked(arr):
+            tile_arr = np.ma.getdata(tile)
+            tile_mask = np.ma.getmask(tile)
+
+            # Make sure image data is the same
+            assert pytest.approx(np.min(tile_arr), 2) == np.min(rio_tile_arr)
+            assert pytest.approx(np.mean(tile_arr), 2) == np.mean(rio_tile_arr)
+            assert pytest.approx(np.max(tile_arr), 2) == np.max(rio_tile_arr)
+
+            # Make sure mask data is the same
+            rio_mask_counts = np.unique(rio_tile_mask, return_counts=True)
+            tile_mask_counts = np.unique(tile_mask, return_counts=True)
+            assert rio_mask_counts[0].all() == tile_mask_counts[0].all()
+            assert rio_mask_counts[1].all() == tile_mask_counts[1].all()
+        else:
+            assert pytest.approx(np.min(tile), 2) == np.min(rio_tile_arr)
+            assert pytest.approx(np.mean(tile), 2) == np.mean(rio_tile_arr)
+            assert pytest.approx(np.max(tile), 2) == np.max(rio_tile_arr)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
- Adds `cog.mask_ifds` attribute
- Read internal mask if present.  Image data is masked to create a `numpy.ma.masked_array`
- Change band indexing from `(height, width, bands)` to `(bands, height, width)`, it works better this way with masked arrays
- Add tests for mask bands
- More reliable numpy array comparison in test cases

Closes #11 

#### Comparison to rasterio:
![image (15)](https://user-images.githubusercontent.com/40916268/82776227-d85ea200-9e0f-11ea-8c50-c9481afc9281.png)


#### TODOs:
- [x] Update README
- [x] Request image/mask concurrently
- [ ] ~Maybe write a `MaskIFD` class~